### PR TITLE
Migrate a schedule Event resource to a Schedulev2 resource

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -161,11 +161,13 @@ Resources:
       # Role: arn:aws:iam::949140100595:role/service-role/monitor_bms-role-zswvtb9u
       Role: !GetAtt BmsMonitoringLambdaRole.Arn
       Events:
-        # The length of "BmsCheckWebsitePeriodicallyFunCheckWebsiteScheduledEventLambdaTarget" is 71
+        # see: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-function-schedule.html
+        # see: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-function-schedulev2.html
         Event1:
-          Type: Schedule
+          Type: ScheduleV2
           Properties:
-            Schedule: rate(30 minutes)
+            Name: !Sub "bms-http-monitor-scheduled-trigger-${Stage}"
+            ScheduleExpression: "rate(60 minutes)"
       Environment:
         Variables:
           MONITOR_URL: http://b-ms.info/


### PR DESCRIPTION
- [Schedule \- AWS Serverless Application Model](https://docs.aws.amazon.com/ja_jp/serverless-application-model/latest/developerguide/sam-property-function-schedule.html)
- [ScheduleV2 \- AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-function-schedulev2.html)