### PR TITLE
fix: mypy エラー回避のための型注釈と None ガードを追加

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -238,15 +238,6 @@ dependencies = [
     { name = "urllib3" },
 ]
 
-[package.optional-dependencies]
-dev = [
-    { name = "aws-sam-cli" },
-    { name = "mypy" },
-    { name = "notebook" },
-    { name = "pytest" },
-    { name = "types-requests" },
-]
-
 [package.dev-dependencies]
 dev = [
     { name = "aws-sam-cli" },
@@ -259,13 +250,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aws-sam-cli", marker = "extra == 'dev'", specifier = ">=1.135.0" },
     { name = "boto3", specifier = ">=1.37.16" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.15.0" },
-    { name = "notebook", marker = "extra == 'dev'", specifier = ">=7.3.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3" },
     { name = "requests", specifier = ">=2.25" },
-    { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.32.0.20250306" },
     { name = "urllib3", specifier = "<3" },
 ]
 


### PR DESCRIPTION
主な変更点:
- MONITOR_URL を Optional から必須化（未設定時に ValueError）
- DB 行取得の None ガードを追加し、初回は初期レコードを挿入
- SqliteOnS3Handler の属性/返り値に型注釈を付与し、常に Connection を返すよう修正
- slack 送信 payload 型を dict[str, Any] に明確化
- requests の例外型を requests.exceptions から import に変更

これにより mypy の型不一致を解消し、実行時の潜在的不具合（None 参照）も軽減します。